### PR TITLE
Update linting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2025-11-24
+
+### Added
+- Added linting rules to reduce review work in PRs
+- Added exception for using `X` as a variable name for the pep8-naming linter
+
 ## [1.0.7] - 2025-10-28
 
 ### Added

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -51,4 +51,7 @@ select = [
 ]
 
 [tool.ruff.lint.pep8-naming]
-ignore-names = ["X"] # Allow the use of X, y as variables in scikit-learn
+ignore-names = ["X"] # Allow the use of X as variable in scikit-learn
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D101", "D102", "D103"] # Allow unit tests without docstring

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -45,9 +45,9 @@ select = [
     "A",    # flake8-builtins (overwriting python builtins)
     "PTH",  # flake8-use-pathlib
     "N",    # pep8-naming
-    "D101", # pydocstyle: Missing DOCSTRING in class
-    "D102", # pydocstyle: Missing DOCSTRING in method
-    "D103", # pydocstyle: Missing DOCSTRING in function
+    "D101", # pydocstyle: Missing docstring in class
+    "D102", # pydocstyle: Missing docstring in method
+    "D103", # pydocstyle: Missing docstring in function
 ]
 
 [tool.ruff.lint.pep8-naming]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "{{cookiecutter.package_name}}"
 version = "{{cookiecutter.version}}"
 authors = [
-  { name="{{cookiecutter.full_name}}", email="{{cookiecutter.email}}" },
+    { name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}" },
 ]
 description = "{{cookiecutter.project_short_description}}"
 readme = "README.md"
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-dependencies =[]
+dependencies = []
 
 [dependency-groups]
 dev = [
@@ -25,9 +25,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "rsconnect-python>=1.24.0",
 ]
-lint = [
-    "ruff>=0.7.1",
-]
+lint = ["ruff>=0.7.1"]
 
 [tool.uv]
 default-groups = ["dev", "lint"]
@@ -37,10 +35,20 @@ src = ["src"]
 
 [tool.ruff.lint]
 select = [
-    "B",  # flake8-bugbear
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
+    "B",    # flake8-bugbear
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
     "C90",  # mccabe complexity
-    "I",  # isort
+    "I",    # isort
+    "ERA",  # Eradicate (commented out code)
+    "A",    # flake8-buitins (overwriting python builtins)
+    "PTH",  # flake8-use-pathlib
+    "N",    # pep8-naming
+    "D101", # pydocstyle: Missing DOCSTRING in class
+    "D102", # pydocstyle: Missing DOCSTRING in method
+    "D103", # pydocstyle: Missing DOCSTRING in function
 ]
+
+[tool.ruff.lint.pep8-naming]
+ignore-names = ["X"] # Allow the use of X, y as variables in scikit-learn

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -42,7 +42,7 @@ select = [
     "C90",  # mccabe complexity
     "I",    # isort
     "ERA",  # Eradicate (commented out code)
-    "A",    # flake8-buitins (overwriting python builtins)
+    "A",    # flake8-builtins (overwriting python builtins)
     "PTH",  # flake8-use-pathlib
     "N",    # pep8-naming
     "D101", # pydocstyle: Missing DOCSTRING in class


### PR DESCRIPTION
## [1.0.8] - 2025-11-24

### Added
- Added linting rules to reduce review work in PRs
- Added exception for using `X` as a variable name for the pep8-naming linter